### PR TITLE
Fix deps.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule ExAws.Acm.MixProject do
   defp deps do
     [
       {:credo, "~> 0.0", only: [:dev, :test]},
-      {:dialyxir, "~> 0.0"},
+      {:dialyxir, "~> 0.0", only: [:dev, :test]},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:hackney, ">= 0.0.0", only: [:dev, :test]},
       {:mix_test_watch, "~> 0.0", only: :dev, runtime: false},


### PR DESCRIPTION
Why:

* For some reason dialyxir needs wx.app which makes it difficult to use
  this app inside of Docker and other environments without wx.app.

This change addresses the need by:

* Limit dialyxir to only be included in dev and test.